### PR TITLE
Fix invalid add/delete recipe command prompt

### DIFF
--- a/src/main/java/fridgy/logic/commands/recipe/AddRecipeCommand.java
+++ b/src/main/java/fridgy/logic/commands/recipe/AddRecipeCommand.java
@@ -23,17 +23,17 @@ public class AddRecipeCommand extends RecipeCommand {
             + RECIPE_KEYWORD
             + ": Adds a recipe to the RecipeBook. "
             + "Parameters: "
-            + PREFIX_NAME + "NAME "
-            + PREFIX_INGREDIENT + "INGREDIENTS"
-            + PREFIX_STEP + "STEPS"
-            + PREFIX_DESCRIPTION + "OPTIONAL DESCRIPTION"
-            + "Example: " + COMMAND_WORD + RECIPE_KEYWORD + " "
-            + PREFIX_NAME + "Burger "
-            + PREFIX_INGREDIENT + "Buns "
-            + PREFIX_INGREDIENT + "Patty "
-            + PREFIX_STEP + "Toast the buns. "
-            + PREFIX_STEP + "Put the patty between the buns. "
-            + PREFIX_DESCRIPTION + "Great burger! ";
+            + PREFIX_NAME + " NAME "
+            + PREFIX_INGREDIENT + " INGREDIENTS"
+            + PREFIX_STEP + " STEPS"
+            + PREFIX_DESCRIPTION + " OPTIONAL DESCRIPTION\n"
+            + "Example: " + COMMAND_WORD + " " + RECIPE_KEYWORD + " "
+            + PREFIX_NAME + " Burger "
+            + PREFIX_INGREDIENT + " Buns "
+            + PREFIX_INGREDIENT + " Patty "
+            + PREFIX_STEP + " Toast the buns. "
+            + PREFIX_STEP + " Put the patty between the buns. "
+            + PREFIX_DESCRIPTION + " Great burger! ";
 
     public static final String MESSAGE_SUCCESS = "New recipe added: %1$s";
     public static final String MESSAGE_DUPLICATE_RECIPE = "This recipe already exists in the Inventory";

--- a/src/main/java/fridgy/logic/commands/recipe/DeleteRecipeCommand.java
+++ b/src/main/java/fridgy/logic/commands/recipe/DeleteRecipeCommand.java
@@ -20,7 +20,7 @@ public class DeleteRecipeCommand extends RecipeCommand {
             + ": Deletes the recipe identified by the index number used in the displayed recipe list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " "
-            + RECIPE_KEYWORD + " "
+            + RECIPE_KEYWORD
             + " 1";
 
     public static final String MESSAGE_SUCCESS = "Recipe deleted: %1$s";


### PR DESCRIPTION
Add spaces for the prompt received by the user when entering an
invalid recipe command.

Fixes #53 