### PR TITLE
Unify Inventory and Recipe Parsers

### DIFF
--- a/src/main/java/fridgy/logic/LogicManager.java
+++ b/src/main/java/fridgy/logic/LogicManager.java
@@ -6,10 +6,10 @@ import java.util.logging.Logger;
 
 import fridgy.commons.core.GuiSettings;
 import fridgy.commons.core.LogsCenter;
-import fridgy.logic.commands.Command;
 import fridgy.logic.commands.CommandResult;
 import fridgy.logic.commands.exceptions.CommandException;
-import fridgy.logic.commands.recipe.RecipeCommand;
+import fridgy.logic.parser.CommandExecutor;
+import fridgy.logic.parser.FridgyParser;
 import fridgy.logic.parser.InventoryParser;
 import fridgy.logic.parser.exceptions.ParseException;
 import fridgy.logic.parser.recipe.RecipeParser;
@@ -29,7 +29,8 @@ public class LogicManager implements Logic {
 
     private final Model model;
     private final Storage storage;
-    private final InventoryParser addressBookParser;
+    private final FridgyParser fridgyParser;
+    private final InventoryParser inventoryParser;
     private final RecipeParser recipeBookParser;
 
     /**
@@ -38,7 +39,8 @@ public class LogicManager implements Logic {
     public LogicManager(Model model, Storage storage) {
         this.model = model;
         this.storage = storage;
-        addressBookParser = new InventoryParser();
+        fridgyParser = new FridgyParser();
+        inventoryParser = new InventoryParser();
         recipeBookParser = new RecipeParser();
     }
 
@@ -46,24 +48,8 @@ public class LogicManager implements Logic {
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
-        CommandResult commandResult;
-
-        // This is a hacked together way of supporting both recipe and ingredient from frontend.
-        // Ideally this routing should be done in parser / use generic command classes.
-        if (commandText.split(" ").length > 1) {
-            switch (commandText.split(" ")[1]) {
-            case "recipe":
-                RecipeCommand recipeCommand = recipeBookParser.parseCommand(commandText);
-                commandResult = recipeCommand.execute(model);
-                break;
-            default:
-                Command command = addressBookParser.parseCommand(commandText);
-                commandResult = command.execute(model);
-            }
-        } else {
-            Command command = addressBookParser.parseCommand(commandText);
-            commandResult = command.execute(model);
-        }
+        CommandExecutor commandExecutor = fridgyParser.parseCommand(commandText);
+        CommandResult commandResult = commandExecutor.apply(model);
 
         try {
             storage.saveInventory(model.getInventory());

--- a/src/main/java/fridgy/logic/parser/CommandExecutor.java
+++ b/src/main/java/fridgy/logic/parser/CommandExecutor.java
@@ -1,0 +1,10 @@
+package fridgy.logic.parser;
+
+import fridgy.logic.commands.CommandResult;
+import fridgy.logic.commands.exceptions.CommandException;
+import fridgy.model.Model;
+
+@FunctionalInterface
+public interface CommandExecutor {
+    CommandResult apply(Model model) throws CommandException;
+}

--- a/src/main/java/fridgy/logic/parser/FridgyParser.java
+++ b/src/main/java/fridgy/logic/parser/FridgyParser.java
@@ -1,0 +1,81 @@
+package fridgy.logic.parser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import fridgy.commons.core.Messages;
+import fridgy.logic.commands.Command;
+import fridgy.logic.commands.ExitCommand;
+import fridgy.logic.commands.HelpCommand;
+import fridgy.logic.commands.recipe.RecipeCommand;
+import fridgy.logic.parser.exceptions.ParseException;
+import fridgy.logic.parser.recipe.RecipeParser;
+
+public class FridgyParser {
+
+    private static final String RECIPE_TYPE = "recipe";
+    private static final String INGREDIENT_TYPE = "ingredient";
+    private static final Pattern TYPED_COMMAND_FORMAT = Pattern
+            .compile("(?<commandWord>\\S+)\\s?(?<taskType>\\S*)?\\s?(?<arguments>.*)?");
+    private static final Pattern GENERAL_COMMAND_FORMAT = Pattern
+            .compile("(?<commandWord>\\S+)(?<arguments>.*)");
+
+    private RecipeParser recipeParser;
+    private InventoryParser inventoryParser;
+
+    /**
+     * Initializes the Command Parser for Fridgy.
+     */
+    public FridgyParser() {
+        this.recipeParser = new RecipeParser();
+        this.inventoryParser = new InventoryParser();
+    }
+
+    /**
+     * Parses user input into a CommandExecutor executable that can be run to
+     * produce a CommandResult.
+     *
+     * @param userInput The user input to be parsed.
+     * @return A CommandExecutor that executes the command when provided a model.
+     * @throws ParseException If user provides invalid input.
+     */
+    public CommandExecutor parseCommand(String userInput) throws ParseException {
+        final Matcher taskMatcher = TYPED_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!taskMatcher.matches()) {
+            return parseGeneralCommand(userInput);
+        }
+        final String taskType = taskMatcher.group("taskType");
+        switch(taskType) {
+
+        case RECIPE_TYPE:
+            RecipeCommand recipeCommand = recipeParser.parseCommand(userInput.trim());
+            return recipeCommand::execute;
+        case INGREDIENT_TYPE:
+            Command ingredientCommand = inventoryParser.parseCommand(userInput.trim());
+            return ingredientCommand::execute;
+        default:
+            return parseGeneralCommand(userInput);
+        }
+    }
+
+    private CommandExecutor parseGeneralCommand(String userInput) throws ParseException {
+        final Matcher matcher = GENERAL_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String commandWord = matcher.group("commandWord");
+
+        switch (commandWord) {
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommand()::execute;
+
+        case HelpCommand.COMMAND_WORD:
+            return new HelpCommand()::execute;
+
+        default:
+            throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
+}

--- a/src/main/java/fridgy/logic/parser/FridgyParser.java
+++ b/src/main/java/fridgy/logic/parser/FridgyParser.java
@@ -18,7 +18,7 @@ public class FridgyParser {
     private static final Pattern TYPED_COMMAND_FORMAT = Pattern
             .compile("(?<commandWord>\\S+)\\s?(?<taskType>\\S*)?\\s?(?<arguments>.*)?");
     private static final Pattern GENERAL_COMMAND_FORMAT = Pattern
-            .compile("(?<commandWord>\\S+)(?<arguments>.*)");
+            .compile("(?<commandWord>^\\S*$)");
 
     private RecipeParser recipeParser;
     private InventoryParser inventoryParser;

--- a/src/main/java/fridgy/logic/parser/InventoryParser.java
+++ b/src/main/java/fridgy/logic/parser/InventoryParser.java
@@ -9,7 +9,6 @@ import fridgy.logic.commands.ClearCommand;
 import fridgy.logic.commands.Command;
 import fridgy.logic.commands.DeleteCommand;
 import fridgy.logic.commands.EditCommand;
-import fridgy.logic.commands.ExitCommand;
 import fridgy.logic.commands.FindCommand;
 import fridgy.logic.commands.HelpCommand;
 import fridgy.logic.commands.ListCommand;
@@ -59,12 +58,6 @@ public class InventoryParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommandParser().parse(arguments);
-
-        case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
-
-        case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
 
         default:
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND);

--- a/src/test/java/fridgy/logic/parser/FridgyParserTest.java
+++ b/src/test/java/fridgy/logic/parser/FridgyParserTest.java
@@ -1,0 +1,170 @@
+package fridgy.logic.parser;
+
+import static fridgy.logic.parser.recipe.RecipeCommandParserTestUtil.VALID_ADD_COMMAND_ALL_PREFIX_PRESENT;
+import static fridgy.logic.parser.recipe.RecipeCommandParserTestUtil.VALID_DEL_COMMAND;
+import static fridgy.logic.parser.recipe.RecipeCommandParserTestUtil.VALID_VIEW_COMMAND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import fridgy.commons.core.index.Index;
+import fridgy.logic.commands.AddCommand;
+import fridgy.logic.commands.ClearCommand;
+import fridgy.logic.commands.CommandResult;
+import fridgy.logic.commands.DeleteCommand;
+import fridgy.logic.commands.ExitCommand;
+import fridgy.logic.commands.HelpCommand;
+import fridgy.logic.commands.exceptions.CommandException;
+import fridgy.logic.commands.recipe.AddRecipeCommand;
+import fridgy.logic.commands.recipe.DeleteRecipeCommand;
+import fridgy.logic.commands.recipe.ViewRecipeCommand;
+import fridgy.logic.parser.exceptions.ParseException;
+import fridgy.model.Inventory;
+import fridgy.model.Model;
+import fridgy.model.ModelManager;
+import fridgy.model.RecipeBook;
+import fridgy.model.ingredient.ExpiryDate;
+import fridgy.model.ingredient.Ingredient;
+import fridgy.model.ingredient.Name;
+import fridgy.model.ingredient.Quantity;
+import fridgy.model.recipe.Recipe;
+import fridgy.model.tag.Tag;
+import fridgy.testutil.RecipeBuilder;
+
+public class FridgyParserTest {
+    private static final String EMPTY_COMMAND = "";
+    private static final String INVALID_SINGLE_WORD_COMMAND = "kekw";
+    private static final String VALID_SINGLE_WORD_HELP_COMMAND = "help";
+    private static final String VALID_SINGLE_WORD_EXIT_COMMAND = "exit";
+    private static final String INVALID_DOUBLE_WORD_RECIPE_COMMAND = "add recipe";
+    private static final String INVALID_DOUBLE_WORD_INGREDIENT_COMMAND = "delete ingredient";
+    private static final String INVALID_DOUBLE_WORD_GENERAL_COMMAND = "why tho";
+    private static final String VALID_DOUBLE_WORD_CLEAR_COMMAND = "clear ingredient";
+    private static final String INVALID_TRIPLE_WORD_RECIPE_COMMAND = "kek recipe why";
+    private static final String INVALID_TRIPLE_WORD_INGREDIENT_COMMAND = "oh ingredient hello";
+    private static final String INVALID_TRIPLE_WORD_GENERAL_COMMAND = "ooga la booga";
+    private static final String VALID_TRIPLE_WORD_ADD_INGREDIENT_COMMAND = "add ingredient -n ingr1 -q 20g"
+            + " -t tag -e 20-10-2021";
+    private static final String VALID_TRIPLE_WORD_DEL_INGREDIENT_COMMAND = "delete ingredient 1";
+
+    private static final FridgyParser testParser = new FridgyParser();
+
+    @Test
+    public void parseCommand_emptyInput_throwsParseException() {
+        assertThrows(ParseException.class, () -> testParser.parseCommand(EMPTY_COMMAND));
+    }
+
+    @Test
+    public void parseCommand_invalidSingleTokenCommand_throwsParseException() {
+        assertThrows(ParseException.class, () -> testParser.parseCommand(INVALID_SINGLE_WORD_COMMAND));
+    }
+
+    @Test
+    public void parseCommand_validSingleTokenGeneralCommand_returnsCorrectCommandResult() {
+        Model testModel = new ModelManager();
+        CommandResult expected1 = new ExitCommand().execute(testModel);
+        CommandResult expected2 = new HelpCommand().execute(testModel);
+        try {
+            CommandResult result1 = testParser.parseCommand(VALID_SINGLE_WORD_EXIT_COMMAND).apply(testModel);
+            CommandResult result2 = testParser.parseCommand(VALID_SINGLE_WORD_HELP_COMMAND).apply(testModel);
+            assertEquals(expected1, result1);
+            assertEquals(expected2, result2);
+        } catch (ParseException pe) {
+            Assertions.fail("ParseException thrown!");
+        } catch (Exception e) {
+            Assertions.fail("Exception thrown!");
+        }
+    }
+
+    @Test
+    public void parseCommand_invalidDoubleTokenCommand_throwsParseException() {
+        assertThrows(ParseException.class, () -> testParser.parseCommand(INVALID_DOUBLE_WORD_RECIPE_COMMAND));
+        assertThrows(ParseException.class, () -> testParser.parseCommand(INVALID_DOUBLE_WORD_INGREDIENT_COMMAND));
+        assertThrows(ParseException.class, () -> testParser.parseCommand(INVALID_DOUBLE_WORD_GENERAL_COMMAND));
+    }
+
+    @Test
+    public void parseCommand_validDoubleTokenCommand_returnsCorrectCommandResult() {
+        Model testModel = new ModelManager();
+        CommandResult expected = new ClearCommand().execute(testModel);
+        try {
+            CommandResult result = testParser.parseCommand(VALID_DOUBLE_WORD_CLEAR_COMMAND).apply(testModel);
+            assertEquals(expected, result);
+        } catch (CommandException ce) {
+            Assertions.fail("CommandException thrown!");
+        } catch (ParseException pe) {
+            Assertions.fail("ParseException thrown!");
+        }
+    }
+
+    @Test
+    public void parseCommand_invalidTripleTokenCommand_throwsParseException() {
+        assertThrows(ParseException.class, () -> testParser.parseCommand(INVALID_TRIPLE_WORD_GENERAL_COMMAND));
+        assertThrows(ParseException.class, () -> testParser.parseCommand(INVALID_TRIPLE_WORD_INGREDIENT_COMMAND));
+        assertThrows(ParseException.class, () -> testParser.parseCommand(INVALID_TRIPLE_WORD_RECIPE_COMMAND));
+    }
+
+    @Test
+    public void parseCommand_validTripleTokenRecipeCommand_returnsCorrectCommandResult() {
+        Model testModel = new ModelManager();
+        Recipe testRecipe = new RecipeBuilder()
+                .withName("monke")
+                .withIngredients(Arrays.asList("ingr1"))
+                .withSteps(Arrays.asList("why tho"))
+                .withDescription("optional")
+                .build();
+        try {
+            CommandResult expectedAdd = new AddRecipeCommand(testRecipe).execute(testModel);
+            CommandResult expectedView = new ViewRecipeCommand(Index.fromZeroBased(0)).execute(testModel);
+            CommandResult expectedDelete = new DeleteRecipeCommand(Index.fromZeroBased(0)).execute(testModel);
+
+            // Reinitialize testModel
+            testModel.setRecipeBook(new RecipeBook());
+
+            CommandResult resultAdd = testParser.parseCommand(VALID_ADD_COMMAND_ALL_PREFIX_PRESENT).apply(testModel);
+            CommandResult resultView = testParser.parseCommand(VALID_VIEW_COMMAND).apply(testModel);
+            CommandResult resultDelete = testParser.parseCommand(VALID_DEL_COMMAND).apply(testModel);
+
+            assertTrue(resultAdd.equals(expectedAdd)
+                    && resultDelete.equals(expectedDelete)
+                    && resultView.equals(expectedView));
+        } catch (CommandException ce) {
+            Assertions.fail("CommandException thrown!");
+        } catch (ParseException pe) {
+            Assertions.fail("ParseException thrown!");
+        }
+    }
+
+    @Test
+    public void parseCommand_validTripleTokenIngredientCommand_returnsCorrectCommandResult() {
+        Model testModel = new ModelManager();
+        Ingredient testIngredient = new Ingredient(new Name("ingr1"), new Quantity("20g"),
+                Set.of(new Tag("tag")), new ExpiryDate("20-10-2021"));
+
+        try {
+            CommandResult expectedAdd = new AddCommand(testIngredient).execute(testModel);
+            CommandResult expectedDelete = new DeleteCommand(Index.fromZeroBased(0)).execute(testModel);
+
+            // Reinitialize testModel
+            testModel.setInventory(new Inventory());
+
+            CommandResult resultAdd = testParser
+                    .parseCommand(VALID_TRIPLE_WORD_ADD_INGREDIENT_COMMAND).apply(testModel);
+            CommandResult resultDelete = testParser
+                    .parseCommand(VALID_TRIPLE_WORD_DEL_INGREDIENT_COMMAND).apply(testModel);
+            assertTrue(resultAdd.equals(expectedAdd)
+                    && resultDelete.equals(expectedDelete));
+
+        } catch (CommandException ce) {
+            Assertions.fail("CommandException thrown!");
+        } catch (ParseException pe) {
+            Assertions.fail("ParseException thrown!");
+        }
+    }
+}

--- a/src/test/java/fridgy/logic/parser/InventoryParserTest.java
+++ b/src/test/java/fridgy/logic/parser/InventoryParserTest.java
@@ -17,7 +17,6 @@ import fridgy.logic.commands.CommandTestUtil;
 import fridgy.logic.commands.DeleteCommand;
 import fridgy.logic.commands.EditCommand;
 import fridgy.logic.commands.EditCommand.EditIngredientDescriptor;
-import fridgy.logic.commands.ExitCommand;
 import fridgy.logic.commands.FindCommand;
 import fridgy.logic.commands.HelpCommand;
 import fridgy.logic.commands.ListCommand;
@@ -90,23 +89,11 @@ public class InventoryParserTest {
     }
 
     @Test
-    public void parseCommand_exit() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
-    }
-
-    @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
-    }
-
-    @Test
-    public void parseCommand_help() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
     }
 
     @Test

--- a/src/test/java/fridgy/logic/parser/recipe/RecipeCommandParserTestUtil.java
+++ b/src/test/java/fridgy/logic/parser/recipe/RecipeCommandParserTestUtil.java
@@ -50,6 +50,9 @@ public class RecipeCommandParserTestUtil {
     public static final String INVALID_DEL_COMMAND_MESSAGE = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
             DeleteRecipeCommand.MESSAGE_USAGE);
 
+    //------------------------------------VALID VIEW RECIPE COMMANDS-------------------------------------------------
+    public static final String VALID_VIEW_COMMAND = "view recipe 1";
+
     /**
      * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created
      * equals to {@code expectedCommand}.


### PR DESCRIPTION
Unified parsing of all user input under a single FridgyParser, which routes the command to either RecipeParser or InventoryParser depending on the type of user input. General commands that do not fall under either Recipe/InventoryParser will be handled in FridgyParser.

FridgyParser parses commands into CommandExecutors, which can be applied to a model by doing `command.apply(model)`.

Fixes #74 