### PR TITLE
Edit find by keyword behaviour

### DIFF
--- a/src/main/java/fridgy/commons/util/StringUtil.java
+++ b/src/main/java/fridgy/commons/util/StringUtil.java
@@ -13,11 +13,11 @@ public class StringUtil {
 
     /**
      * Returns true if the {@code sentence} contains the {@code word}.
-     *   Ignores case, but a full word match is required.
+     *   Ignores case, only a partial match is required.
      *   <br>examples:<pre>
      *       containsWordIgnoreCase("ABc def", "abc") == true
      *       containsWordIgnoreCase("ABc def", "DEF") == true
-     *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
+     *       containsWordIgnoreCase("ABc def", "g") == false //word does not contain "g"
      *       </pre>
      * @param sentence cannot be null
      * @param word cannot be null, cannot be empty, must be a single word
@@ -34,7 +34,19 @@ public class StringUtil {
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
 
         return Arrays.stream(wordsInPreppedSentence)
-                .anyMatch(preppedWord::equalsIgnoreCase);
+                .anyMatch(x -> containsIgnoreCase(x, preppedWord));
+    }
+
+    /**
+     * Returns true if {@code substring} is a substring of the the provided {@code word}.
+     * Case is ignored when performing the match.
+     *
+     * @param word The word to be tested against.
+     * @param substring The target substring to find.
+     * @return true if {@code substring} is a substring of {@code word}.
+     */
+    public static boolean containsIgnoreCase(String word, String substring) {
+        return word.toLowerCase().contains(substring.toLowerCase());
     }
 
     /**

--- a/src/test/java/fridgy/commons/util/StringUtilTest.java
+++ b/src/test/java/fridgy/commons/util/StringUtilTest.java
@@ -110,9 +110,13 @@ public class StringUtilTest {
         assertFalse(StringUtil.containsWordIgnoreCase("", "abc")); // Boundary case
         assertFalse(StringUtil.containsWordIgnoreCase("    ", "123"));
 
-        // Matches a partial word only
-        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
+        // No matches in sentence
+        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "dd"));
+        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "dddd"));
         assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
+
+        // Matches a partial word only
+        assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
 
         // Matches word in the sentence, different upper/lower case letters
         assertTrue(StringUtil.containsWordIgnoreCase("aaa bBb ccc", "Bbb")); // First word (boundary case)


### PR DESCRIPTION
Edited Find functionality such that users can search for a recipe
or ingredient by a partial name match as opposed to a full name
match.

Fixes #108 