### PR TITLE
More specific error messages & allow spaces between tags

### DIFF
--- a/src/main/java/fridgy/commons/core/Messages.java
+++ b/src/main/java/fridgy/commons/core/Messages.java
@@ -7,6 +7,8 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String TYPE_INVALID_COMMAND_FORMAT = "Unknown type";
+    public static final String TYPE_EXPECTED = "(Expected either 'ingredient' or 'recipe')";
     public static final String MESSAGE_INVALID_INGREDIENT_DISPLAYED_INDEX = "The ingredient index provided is invalid";
     public static final String MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX = "The recipe index provided is invalid!";
     public static final String MESSAGE_INGREDIENTS_LISTED_OVERVIEW = "%1$d ingredient%2$s listed!";

--- a/src/main/java/fridgy/logic/commands/DeleteCommand.java
+++ b/src/main/java/fridgy/logic/commands/DeleteCommand.java
@@ -20,7 +20,7 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + INGREDIENT_KEYWORD
             + ": Deletes the ingredient by index.\n"
-            + "Parameters: INDEX\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " " + INGREDIENT_KEYWORD + " 1";
 
     public static final String MESSAGE_DELETE_INGREDIENT_SUCCESS = "Deleted Ingredient:\n%1$s";

--- a/src/main/java/fridgy/logic/commands/EditCommand.java
+++ b/src/main/java/fridgy/logic/commands/EditCommand.java
@@ -34,7 +34,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + " "
             + INGREDIENT_KEYWORD + ": Edits details of the ingredient. "
             + "Existing values are replaced with input values.\n"
-            + "Parameters: INDEX "
+            + "Parameters: INDEX (must be a positive integer) "
             + "[" + CliSyntax.PREFIX_NAME + " NAME] "
             + "[" + CliSyntax.PREFIX_QUANTITY + " QUANTITY] "
             + "[" + CliSyntax.PREFIX_EXPIRY + " EXPIRY DATE] "

--- a/src/main/java/fridgy/logic/commands/ListCommand.java
+++ b/src/main/java/fridgy/logic/commands/ListCommand.java
@@ -16,9 +16,9 @@ public class ListCommand extends Command {
     public static final String INGREDIENT_KEYWORD = "ingredient";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " "
-            + INGREDIENT_KEYWORD + ": Lists and sorts all ingredients.\n";
+            + INGREDIENT_KEYWORD + ": Lists all ingredients.\n";
 
-    public static final String MESSAGE_SUCCESS = "Listed and sorted all ingredients";
+    public static final String MESSAGE_SUCCESS = "Listed all ingredients";
 
 
     @Override

--- a/src/main/java/fridgy/logic/commands/recipe/DeleteRecipeCommand.java
+++ b/src/main/java/fridgy/logic/commands/recipe/DeleteRecipeCommand.java
@@ -21,7 +21,7 @@ public class DeleteRecipeCommand extends RecipeCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + RECIPE_KEYWORD
             + ": Deletes the recipe by index.\n"
-            + "Parameters: INDEX\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " "
             + RECIPE_KEYWORD
             + " 1";

--- a/src/main/java/fridgy/model/ingredient/Quantity.java
+++ b/src/main/java/fridgy/model/ingredient/Quantity.java
@@ -13,7 +13,7 @@ public class Quantity {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Quantity should be greater than zero. \n"
+            "Quantity should not be empty. \n"
                     + "Include units in grams (g) or litres (l) when applicable. \n"
                     + "Do not input units for discrete ingredients (i.e. bottle, pieces, etc.) \n"
                     + "SI prefixes for units: milli (m) and kilo (k) are accepted. \n";

--- a/src/main/java/fridgy/model/ingredient/Quantity.java
+++ b/src/main/java/fridgy/model/ingredient/Quantity.java
@@ -11,9 +11,8 @@ import fridgy.model.util.QuantityCalc;
  */
 public class Quantity {
 
-
     public static final String MESSAGE_CONSTRAINTS =
-            "Quantity should not be empty. \n"
+            "Quantity is invalid. (Quantity must be a valid number greater than 0) \n"
                     + "Include units in grams (g) or litres (l) when applicable. \n"
                     + "Do not input units for discrete ingredients (i.e. bottle, pieces, etc.) \n"
                     + "SI prefixes for units: milli (m) and kilo (k) are accepted. \n";

--- a/src/main/java/fridgy/model/tag/Tag.java
+++ b/src/main/java/fridgy/model/tag/Tag.java
@@ -10,8 +10,8 @@ import fridgy.commons.util.AppUtil;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tag names should be alphanumeric";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9]+( [a-zA-Z0-9]+)*$";
     public static final Tag EXPIRED = new Tag("expired");
     public static final Tag EXPIRING = new Tag("expiring");
     public final String tagName;

--- a/src/main/java/fridgy/ui/IngredientListPanel.java
+++ b/src/main/java/fridgy/ui/IngredientListPanel.java
@@ -32,8 +32,8 @@ public class IngredientListPanel extends UiPart<Region> {
         ingredientListView.getSelectionModel().selectedItemProperty().addListener(
                 new ChangeListener<Ingredient>() {
                     public void changed(ObservableValue<? extends Ingredient> ov,
-                                        Ingredient old_val, Ingredient new_val) {
-                        activeItemPanel.update(new_val);
+                                        Ingredient oldVal, Ingredient newVal) {
+                        activeItemPanel.update(newVal);
                     }
                 });
     }

--- a/src/main/java/fridgy/ui/RecipeListPanel.java
+++ b/src/main/java/fridgy/ui/RecipeListPanel.java
@@ -39,8 +39,8 @@ public class RecipeListPanel extends UiPart<Region> {
         recipeListView.getSelectionModel().selectedItemProperty().addListener(
                 new ChangeListener<Recipe>() {
                     public void changed(ObservableValue<? extends Recipe> ov,
-                                        Recipe old_val, Recipe new_val) {
-                        activeItemPanel.update(new_val);
+                                        Recipe oldVal, Recipe newVal) {
+                        activeItemPanel.update(newVal);
                     }
                 });
     }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -16,7 +16,7 @@
 <?import javafx.stage.Stage?>
 <?import javafx.scene.control.ScrollPane?>
 
-<fx:root minHeight="900" minWidth="985" onCloseRequest="#handleExit" title="Fridgy" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="600" minWidth="600" onCloseRequest="#handleExit" title="Fridgy" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/cute_fridge.png" />
     </icons>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -16,7 +16,7 @@
 <?import javafx.stage.Stage?>
 <?import javafx.scene.control.ScrollPane?>
 
-<fx:root minHeight="600" minWidth="600" onCloseRequest="#handleExit" title="Fridgy" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="900" minWidth="985" onCloseRequest="#handleExit" title="Fridgy" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/cute_fridge.png" />
     </icons>

--- a/src/test/java/fridgy/logic/LogicManagerTest.java
+++ b/src/test/java/fridgy/logic/LogicManagerTest.java
@@ -55,7 +55,7 @@ public class LogicManagerTest {
     @Test
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
-        assertParseException(invalidCommand, Messages.MESSAGE_UNKNOWN_COMMAND);
+        assertParseException(invalidCommand, Messages.MESSAGE_UNKNOWN_COMMAND + " '" + invalidCommand + "'");
     }
 
     @Test


### PR DESCRIPTION
Fixes #194, fixes #180, fixes #169, fixes #144, fixes #66, fixes #206

- If command word is invalid it will throw unknown command error with the wrong command
<img width="555" alt="Screenshot 2021-10-31 at 2 05 03 AM" src="https://user-images.githubusercontent.com/38195541/139553696-7ef08842-5ea4-418a-84b1-b9886c2532b0.png">

- If command type is invalid it will throw unknown type instead
<img width="573" alt="Screenshot 2021-10-31 at 2 05 12 AM" src="https://user-images.githubusercontent.com/38195541/139553724-e3878e5e-6a98-437b-8013-4ab42701aaf2.png">

- allow spaces between tag names (maybe need to mention in UG)
<img width="311" alt="Screenshot 2021-10-31 at 2 15 26 AM" src="https://user-images.githubusercontent.com/38195541/139553912-fd452b2a-34b1-4b5c-b088-eaeb4a2197aa.png">

