### PR TITLE
Fix error messages and date parsing

### DIFF
--- a/src/main/java/fridgy/commons/core/Messages.java
+++ b/src/main/java/fridgy/commons/core/Messages.java
@@ -8,10 +8,11 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String TYPE_INVALID_COMMAND_FORMAT = "Unknown type";
-    public static final String TYPE_EXPECTED = "(Expected either 'ingredient' or 'recipe')";
-    public static final String MESSAGE_INVALID_INGREDIENT_DISPLAYED_INDEX = "The ingredient index provided is invalid";
+    public static final String TYPE_EXPECTED = "Expected either 'ingredient' or 'recipe'.";
+    public static final String MISSING_TYPE = "Missing type in command. " + TYPE_EXPECTED;
+    public static final String MESSAGE_INVALID_INGREDIENT_DISPLAYED_INDEX = "The ingredient index provided is invalid!";
     public static final String MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX = "The recipe index provided is invalid!";
-    public static final String MESSAGE_INGREDIENTS_LISTED_OVERVIEW = "%1$d ingredient%2$s listed!";
-    public static final String MESSAGE_RECIPES_LISTED_OVERVIEW = "%1$d recipe%2$s listed!";
+    public static final String MESSAGE_INGREDIENTS_LISTED_OVERVIEW = "Found %1$d ingredient%2$s!";
+    public static final String MESSAGE_RECIPES_LISTED_OVERVIEW = "Found %1$d recipe%2$s!";
     public static final String MESSAGE_DELETE_REPEATED_INDICES = "There are repeated indices provided for deletion!";
 }

--- a/src/main/java/fridgy/commons/core/Messages.java
+++ b/src/main/java/fridgy/commons/core/Messages.java
@@ -9,7 +9,9 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String TYPE_INVALID_COMMAND_FORMAT = "Unknown type";
     public static final String TYPE_EXPECTED = "Expected either 'ingredient' or 'recipe'.";
-    public static final String MISSING_TYPE = "Missing type in command. " + TYPE_EXPECTED;
+    public static final String TYPE_RECIPE_EXPECTED = "Expected 'recipe'.";
+    public static final String MESSAGE_WRONG_TYPE = "Wrong type";
+    public static final String MESSAGE_MISSING_TYPE = "Missing type in command. %1$s";
     public static final String MESSAGE_INVALID_INGREDIENT_DISPLAYED_INDEX = "The ingredient index provided is invalid!";
     public static final String MESSAGE_INVALID_RECIPE_DISPLAYED_INDEX = "The recipe index provided is invalid!";
     public static final String MESSAGE_INGREDIENTS_LISTED_OVERVIEW = "Found %1$d ingredient%2$s!";

--- a/src/main/java/fridgy/logic/commands/DeleteCommand.java
+++ b/src/main/java/fridgy/logic/commands/DeleteCommand.java
@@ -27,7 +27,7 @@ public class DeleteCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " " + INGREDIENT_KEYWORD + " 1 2 3";
 
-    public static final String MESSAGE_DELETE_INGREDIENT_SUCCESS = "Deleted %1$d ingredients";
+    public static final String MESSAGE_DELETE_INGREDIENT_SUCCESS = "Deleted %1$d ingredient%2$s!";
 
     private final List<Index> targetIndices = new ArrayList<>();
 
@@ -62,7 +62,10 @@ public class DeleteCommand extends Command {
         }
         // delete all chosen ingredients
         toDelete.forEach(model::delete);
-        return new CommandResult(String.format(MESSAGE_DELETE_INGREDIENT_SUCCESS, targetIndices.size()));
+
+        int size = targetIndices.size();
+        String plural = size == 0 || size == 1 ? "" : "s";
+        return new CommandResult(String.format(MESSAGE_DELETE_INGREDIENT_SUCCESS, size, plural));
     }
 
     @Override

--- a/src/main/java/fridgy/logic/commands/ListCommand.java
+++ b/src/main/java/fridgy/logic/commands/ListCommand.java
@@ -18,7 +18,7 @@ public class ListCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + " "
             + INGREDIENT_KEYWORD + ": Lists all ingredients.\n";
 
-    public static final String MESSAGE_SUCCESS = "Listed all ingredients";
+    public static final String MESSAGE_SUCCESS = "Listed all ingredients!";
 
 
     @Override

--- a/src/main/java/fridgy/logic/commands/ViewCommand.java
+++ b/src/main/java/fridgy/logic/commands/ViewCommand.java
@@ -17,7 +17,7 @@ public class ViewCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + INGREDIENT_KEYWORD
             + ": view the ingredient identified by the index number used in the displayed ingredient list.\n"
-            + "Parameters: INDEX\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " " + INGREDIENT_KEYWORD + " 1";
 
     public static final String MESSAGE_SUCCESS = "Viewing ingredient:\n%1$s";

--- a/src/main/java/fridgy/logic/commands/recipe/AddRecipeCommand.java
+++ b/src/main/java/fridgy/logic/commands/recipe/AddRecipeCommand.java
@@ -21,7 +21,7 @@ public class AddRecipeCommand extends RecipeCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " "
             + RECIPE_KEYWORD
-            + ": Adds a recipe to the RecipeBook. "
+            + ": Adds a recipe to the RecipeBook.\n"
             + "Parameters: "
             + PREFIX_NAME + " NAME "
             + PREFIX_INGREDIENT + " INGREDIENTS "
@@ -29,8 +29,8 @@ public class AddRecipeCommand extends RecipeCommand {
             + "[" + PREFIX_DESCRIPTION + " DESCRIPTION]\n"
             + "Example: " + COMMAND_WORD + " " + RECIPE_KEYWORD + " "
             + PREFIX_NAME + " Burger "
-            + PREFIX_INGREDIENT + " Buns 2"
-            + PREFIX_INGREDIENT + " Patty 1"
+            + PREFIX_INGREDIENT + " Buns 2 "
+            + PREFIX_INGREDIENT + " Patty 1 "
             + PREFIX_STEP + " Toast the buns. "
             + PREFIX_STEP + " Put the patty between the buns. "
             + PREFIX_DESCRIPTION + " Great burger! ";

--- a/src/main/java/fridgy/logic/commands/recipe/CookRecipeCommand.java
+++ b/src/main/java/fridgy/logic/commands/recipe/CookRecipeCommand.java
@@ -23,7 +23,7 @@ public class CookRecipeCommand extends RecipeCommand {
     public static final String RECIPE_KEYWORD = "recipe";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + RECIPE_KEYWORD
-            + ": Cooks a recipe and deducts the quantity of ingredients from the inventory"
+            + ": Cooks a recipe and deducts the quantity of ingredients from the inventory.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " " + RECIPE_KEYWORD + " 1";
 

--- a/src/main/java/fridgy/logic/commands/recipe/DeleteRecipeCommand.java
+++ b/src/main/java/fridgy/logic/commands/recipe/DeleteRecipeCommand.java
@@ -28,7 +28,7 @@ public class DeleteRecipeCommand extends RecipeCommand {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " " + RECIPE_KEYWORD + " 1 2 3";
 
-    public static final String MESSAGE_DELETE_RECIPE_SUCCESS = "Deleted %1$d recipes";
+    public static final String MESSAGE_DELETE_RECIPE_SUCCESS = "Deleted %1$d recipe%2$s!";
 
     private final List<Index> targetIndices = new ArrayList<>();
 
@@ -63,7 +63,10 @@ public class DeleteRecipeCommand extends RecipeCommand {
         }
         // delete all chosen recipes
         toDelete.forEach(model::delete);
-        return new CommandResult(String.format(MESSAGE_DELETE_RECIPE_SUCCESS, targetIndices.size()));
+
+        int size = targetIndices.size();
+        String plural = size == 0 || size == 1 ? "" : "s";
+        return new CommandResult(String.format(MESSAGE_DELETE_RECIPE_SUCCESS, size, plural));
     }
 
     @Override

--- a/src/main/java/fridgy/logic/commands/recipe/ListRecipeCommand.java
+++ b/src/main/java/fridgy/logic/commands/recipe/ListRecipeCommand.java
@@ -17,7 +17,7 @@ public class ListRecipeCommand extends RecipeCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + " "
             + RECIPE_KEYWORD + ": Lists all recipes.\n";
 
-    public static final String MESSAGE_SUCCESS = "Listed all recipes";
+    public static final String MESSAGE_SUCCESS = "Listed all recipes!";
 
 
     @Override

--- a/src/main/java/fridgy/logic/commands/recipe/ViewRecipeCommand.java
+++ b/src/main/java/fridgy/logic/commands/recipe/ViewRecipeCommand.java
@@ -21,7 +21,7 @@ public class ViewRecipeCommand extends RecipeCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " " + RECIPE_KEYWORD
         + ": Views a recipe by index.\n"
-        + "Parameters: INDEX\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
         + "Example: " + COMMAND_WORD + " "
         + RECIPE_KEYWORD
         + " 1";

--- a/src/main/java/fridgy/logic/parser/FridgyParser.java
+++ b/src/main/java/fridgy/logic/parser/FridgyParser.java
@@ -98,19 +98,23 @@ public class FridgyParser {
             RecipeCommand recipeCommand = recipeParser.parseCommand(userInput.trim());
             return recipeCommand::execute;
         case INGREDIENT_TYPE:
+            if (commandWord.equals(CookRecipeCommand.COMMAND_WORD)) {
+                throw new ParseException(Messages.MESSAGE_WRONG_TYPE + " "
+                        + formatString(taskType)
+                        + ". " + Messages.TYPE_RECIPE_EXPECTED);
+            }
             Command ingredientCommand = inventoryParser.parseCommand(userInput.trim());
             return ingredientCommand::execute;
         case "": // no type
             return parseGeneralCommand(userInput);
         default: // invalid type
             if (COMMAND_NAMES.contains(commandWord)) {
-                if (commandWord.equals(CookRecipeCommand.COMMAND_WORD)) {
-                    recipeParser.parseCommand(userInput.trim());
-                } else {
-                    throw new ParseException(Messages.TYPE_INVALID_COMMAND_FORMAT + " "
-                            + formatString(taskType)
-                            + ". " + Messages.TYPE_EXPECTED);
-                }
+                String expectedType = commandWord.equals(CookRecipeCommand.COMMAND_WORD)
+                        ? Messages.TYPE_RECIPE_EXPECTED
+                        : Messages.TYPE_EXPECTED;
+                throw new ParseException(Messages.TYPE_INVALID_COMMAND_FORMAT + " "
+                        + formatString(taskType)
+                        + ". " + expectedType);
             }
             // invalid command
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND + " "
@@ -137,12 +141,12 @@ public class FridgyParser {
 
         default:
             if (COMMAND_NAMES.contains(commandWord)) {
-                if (commandWord.equals(CookRecipeCommand.COMMAND_WORD)) {
-                    recipeParser.parseCommand(userInput.trim());
-                } else {
-                    throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                            Messages.MISSING_TYPE));
-                }
+                String expectedType = commandWord.equals(CookRecipeCommand.COMMAND_WORD)
+                        ? Messages.TYPE_RECIPE_EXPECTED
+                        : Messages.TYPE_EXPECTED;
+                String missingTypeMessage = String.format(Messages.MESSAGE_MISSING_TYPE, expectedType);
+                throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                            missingTypeMessage));
             }
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND + " "
                     + formatString(commandWord) + ".");

--- a/src/main/java/fridgy/logic/parser/FridgyParser.java
+++ b/src/main/java/fridgy/logic/parser/FridgyParser.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 
 import fridgy.commons.core.Messages;
 import fridgy.logic.commands.AddCommand;
+import fridgy.logic.commands.ClearCommand;
 import fridgy.logic.commands.Command;
 import fridgy.logic.commands.DeleteCommand;
 import fridgy.logic.commands.EditCommand;
@@ -13,6 +14,8 @@ import fridgy.logic.commands.ExitCommand;
 import fridgy.logic.commands.FindCommand;
 import fridgy.logic.commands.HelpCommand;
 import fridgy.logic.commands.ListCommand;
+import fridgy.logic.commands.ViewCommand;
+import fridgy.logic.commands.recipe.CookRecipeCommand;
 import fridgy.logic.commands.recipe.RecipeCommand;
 import fridgy.logic.parser.exceptions.ParseException;
 import fridgy.logic.parser.recipe.RecipeParser;
@@ -23,10 +26,13 @@ import fridgy.logic.parser.recipe.RecipeParser;
 public class FridgyParser {
 
     public static final List<String> COMMAND_NAMES = List.of(AddCommand.COMMAND_WORD,
+            ClearCommand.COMMAND_WORD,
             DeleteCommand.COMMAND_WORD,
             EditCommand.COMMAND_WORD,
             FindCommand.COMMAND_WORD,
-            ListCommand.COMMAND_WORD
+            ListCommand.COMMAND_WORD,
+            ViewCommand.COMMAND_WORD,
+            CookRecipeCommand.COMMAND_WORD
     );
     private static final String RECIPE_TYPE = "recipe";
     private static final String INGREDIENT_TYPE = "ingredient";
@@ -98,13 +104,17 @@ public class FridgyParser {
             return parseGeneralCommand(userInput);
         default: // invalid type
             if (COMMAND_NAMES.contains(commandWord)) {
-                throw new ParseException(Messages.TYPE_INVALID_COMMAND_FORMAT + " "
-                        + formatString(taskType)
-                        + " " + Messages.TYPE_EXPECTED);
+                if (commandWord.equals(CookRecipeCommand.COMMAND_WORD)) {
+                    recipeParser.parseCommand(userInput.trim());
+                } else {
+                    throw new ParseException(Messages.TYPE_INVALID_COMMAND_FORMAT + " "
+                            + formatString(taskType)
+                            + ". " + Messages.TYPE_EXPECTED);
+                }
             }
             // invalid command
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND + " "
-                    + formatString(commandWord));
+                    + formatString(commandWord) + ".");
         }
     }
 
@@ -126,8 +136,16 @@ public class FridgyParser {
             return new HelpCommand()::execute;
 
         default:
+            if (COMMAND_NAMES.contains(commandWord)) {
+                if (commandWord.equals(CookRecipeCommand.COMMAND_WORD)) {
+                    recipeParser.parseCommand(userInput.trim());
+                } else {
+                    throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                            Messages.MISSING_TYPE));
+                }
+            }
             throw new ParseException(Messages.MESSAGE_UNKNOWN_COMMAND + " "
-                    + formatString(commandWord));
+                    + formatString(commandWord) + ".");
         }
     }
 

--- a/src/main/java/fridgy/logic/parser/ParserUtil.java
+++ b/src/main/java/fridgy/logic/parser/ParserUtil.java
@@ -131,9 +131,12 @@ public class ParserUtil {
     /**
      * Parses {@code String name} into a {@code Name}
      */
-    public static fridgy.model.recipe.Name parseRecipeName(String name) {
+    public static fridgy.model.recipe.Name parseRecipeName(String name) throws ParseException {
         requireNonNull(name);
         String trimmedName = name.trim();
+        if (!fridgy.model.recipe.Name.isValidName(trimmedName)) {
+            throw new ParseException(fridgy.model.recipe.Name.MESSAGE_CONSTRAINTS);
+        }
         return new fridgy.model.recipe.Name(trimmedName);
     }
 

--- a/src/main/java/fridgy/model/ingredient/ExpiryDate.java
+++ b/src/main/java/fridgy/model/ingredient/ExpiryDate.java
@@ -27,7 +27,7 @@ public class ExpiryDate implements Comparable<ExpiryDate> {
      *
      * @param date A valid date.
      */
-    public ExpiryDate(String date) throws DateTimeParseException {
+    public ExpiryDate(String date) {
         requireNonNull(date);
         AppUtil.checkArgument(isValidExpiry(date), MESSAGE_CONSTRAINTS);
         expiryDate = LocalDate.parse(date, DATE_FORMATTER);

--- a/src/main/java/fridgy/model/ingredient/ExpiryDate.java
+++ b/src/main/java/fridgy/model/ingredient/ExpiryDate.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 
 import fridgy.commons.util.AppUtil;
 
@@ -14,9 +16,10 @@ import fridgy.commons.util.AppUtil;
 public class ExpiryDate implements Comparable<ExpiryDate> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Expiry Date should be in the format DD-MM-YYYY";
+            "Expiry Date should be a valid date in the format DD-MM-YYYY";
     public static final String VALIDATION_REGEX = "^([0-2]\\d|3[01])-([0]\\d|1[0-2])-\\d{4}$";
-    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-uuuu")
+            .withResolverStyle(ResolverStyle.STRICT);
     public final LocalDate expiryDate;
 
     /**
@@ -24,7 +27,7 @@ public class ExpiryDate implements Comparable<ExpiryDate> {
      *
      * @param date A valid date.
      */
-    public ExpiryDate(String date) {
+    public ExpiryDate(String date) throws DateTimeParseException {
         requireNonNull(date);
         AppUtil.checkArgument(isValidExpiry(date), MESSAGE_CONSTRAINTS);
         expiryDate = LocalDate.parse(date, DATE_FORMATTER);
@@ -38,7 +41,7 @@ public class ExpiryDate implements Comparable<ExpiryDate> {
      * Returns true if a given string is a valid date.
      */
     public static boolean isValidExpiry(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return isValidDate(test) && test.matches(VALIDATION_REGEX);
     }
 
     @Override
@@ -51,6 +54,15 @@ public class ExpiryDate implements Comparable<ExpiryDate> {
         return other == this // short circuit if same object
                 || (other instanceof ExpiryDate // instanceof handles nulls
                 && expiryDate.equals(((ExpiryDate) other).expiryDate)); // state check
+    }
+
+    private static boolean isValidDate(String test) {
+        try {
+            LocalDate.parse(test, DATE_FORMATTER);
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/fridgy/model/ingredient/Name.java
+++ b/src/main/java/fridgy/model/ingredient/Name.java
@@ -11,7 +11,7 @@ import fridgy.commons.util.AppUtil;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Ingredient name should only contain alphanumeric characters and spaces, and it should not be blank";
 
     /*
      * The first character of the description must not be a whitespace,

--- a/src/main/java/fridgy/model/ingredient/Quantity.java
+++ b/src/main/java/fridgy/model/ingredient/Quantity.java
@@ -12,7 +12,7 @@ import fridgy.model.util.QuantityCalc;
 public class Quantity {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Quantity is invalid. (Quantity must be a valid number greater than 0) \n"
+            "Quantity is invalid. Quantity must be a valid number greater than 0 with a valid unit (if any). \n"
                     + "Include units in grams (g) or litres (l) when applicable. \n"
                     + "Do not input units for discrete ingredients (i.e. bottle, pieces, etc.) \n"
                     + "SI prefixes for units: milli (m) and kilo (k) are accepted. \n";

--- a/src/main/java/fridgy/model/recipe/Name.java
+++ b/src/main/java/fridgy/model/recipe/Name.java
@@ -11,7 +11,7 @@ import static java.util.Objects.requireNonNull;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Recipe name should only contain alphanumeric characters and spaces, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,

--- a/src/main/java/fridgy/model/tag/Tag.java
+++ b/src/main/java/fridgy/model/tag/Tag.java
@@ -13,7 +13,8 @@ import fridgy.commons.util.AppUtil;
 public class Tag {
     public static final String[] RESERVED_KEYWORDS = {"expired", "expiring"};
     public static final String MESSAGE_CONSTRAINTS = "Tags should be alphanumeric, and should not use reserved "
-            + "keywords in any case:\n" + Arrays.toString(RESERVED_KEYWORDS);
+            + "keywords in any case: " + Arrays.toString(RESERVED_KEYWORDS) + ".\n"
+            + "Tags with multiple words must only be separated by a single space.";
     public static final String VALIDATION_REGEX = "^[a-zA-Z0-9]+( [a-zA-Z0-9]+)*$";
     public static final Tag EXPIRED = new Tag("expired");
     public static final Tag EXPIRING = new Tag("expiring");

--- a/src/test/java/fridgy/logic/LogicManagerTest.java
+++ b/src/test/java/fridgy/logic/LogicManagerTest.java
@@ -55,7 +55,7 @@ public class LogicManagerTest {
     @Test
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
-        assertParseException(invalidCommand, Messages.MESSAGE_UNKNOWN_COMMAND + " '" + invalidCommand + "'");
+        assertParseException(invalidCommand, Messages.MESSAGE_UNKNOWN_COMMAND + " '" + invalidCommand + "'.");
     }
 
     @Test

--- a/src/test/java/fridgy/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/fridgy/logic/commands/DeleteCommandTest.java
@@ -43,7 +43,7 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_INGREDIENT,
                 INDEX_SECOND_INGREDIENT, INDEX_THIRD_INGREDIENT);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_INGREDIENT_SUCCESS, 3);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_INGREDIENT_SUCCESS, 3, "s");
 
         ModelManager expectedModel = new ModelManager(model.getInventory(), new RecipeBook(), new UserPrefs());
         expectedModel.delete(ingredientToDelete1);
@@ -72,7 +72,7 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_INGREDIENT);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_INGREDIENT_SUCCESS,
-                1);
+                1, "");
 
         Model expectedModel = new ModelManager(model.getInventory(), new RecipeBook(), new UserPrefs());
         expectedModel.delete(ingredientToDelete);
@@ -99,7 +99,7 @@ public class DeleteCommandTest {
         /* Trivial test case where nothing is deleted if there are no arguments passed to varargs. Parser should have
           filtered this out. */
         DeleteCommand deleteCommand = new DeleteCommand();
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_INGREDIENT_SUCCESS, 0);
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_INGREDIENT_SUCCESS, 0, "");
 
         ModelManager expectedModel = new ModelManager(model.getInventory(), new RecipeBook(), new UserPrefs());
 

--- a/src/test/java/fridgy/logic/commands/recipe/DeleteRecipeCommandTest.java
+++ b/src/test/java/fridgy/logic/commands/recipe/DeleteRecipeCommandTest.java
@@ -55,7 +55,7 @@ public class DeleteRecipeCommandTest {
         DeleteRecipeCommand deleteRecipeCommand = new DeleteRecipeCommand(INDEX_FIRST_RECIPE,
                 INDEX_SECOND_RECIPE, INDEX_THIRD_RECIPE);
 
-        String expectedMessage = String.format(DeleteRecipeCommand.MESSAGE_DELETE_RECIPE_SUCCESS, 3);
+        String expectedMessage = String.format(DeleteRecipeCommand.MESSAGE_DELETE_RECIPE_SUCCESS, 3, "s");
 
         ModelManager expectedModel = new ModelManager(new Inventory(), model.getRecipeBook(), new UserPrefs());
         expectedModel.delete(recipeToDelete1);
@@ -84,7 +84,7 @@ public class DeleteRecipeCommandTest {
         DeleteRecipeCommand deleteCommand = new DeleteRecipeCommand(INDEX_FIRST_RECIPE);
 
         String expectedMessage = String.format(DeleteRecipeCommand.MESSAGE_DELETE_RECIPE_SUCCESS,
-                1);
+                1, "");
 
         Model expectedModel = new ModelManager(new Inventory(), model.getRecipeBook(), new UserPrefs());
         expectedModel.delete(recipeToDelete);
@@ -112,7 +112,7 @@ public class DeleteRecipeCommandTest {
         /* Trivial test case where nothing is deleted if there are no arguments passed to varargs. Parser should have
           filtered this out. */
         DeleteRecipeCommand deleteRecipeCommand = new DeleteRecipeCommand();
-        String expectedMessage = String.format(DeleteRecipeCommand.MESSAGE_DELETE_RECIPE_SUCCESS, 0);
+        String expectedMessage = String.format(DeleteRecipeCommand.MESSAGE_DELETE_RECIPE_SUCCESS, 0, "");
 
         ModelManager expectedModel = new ModelManager(new Inventory(), model.getRecipeBook(), new UserPrefs());
 

--- a/src/test/java/fridgy/logic/parser/FridgyParserTest.java
+++ b/src/test/java/fridgy/logic/parser/FridgyParserTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import fridgy.commons.core.Messages;
 import fridgy.commons.core.index.Index;
 import fridgy.logic.commands.AddCommand;
 import fridgy.logic.commands.ClearCommand;
@@ -57,12 +58,59 @@ public class FridgyParserTest {
     private static final String VALID_TRIPLE_WORD_ADD_INGREDIENT_COMMAND = "add ingredient -n ingr1 -q 20g"
             + " -t tag -e 20-10-2021";
     private static final String VALID_TRIPLE_WORD_DEL_INGREDIENT_COMMAND = "delete ingredient 1";
+    private static final String INVALID_TYPE = "rando";
+    private static final String COOK_COMMAND_WORD_WITH_INGREDIENT_TYPE = "cook ingredient";
+    private static final String COOK_COMMAND_WORD_WITH_INVALID_TYPE = "cook " + INVALID_TYPE;
+    private static final String COOK_COMMAND_WORD_WITH_MISSING_TYPE = "cook";
+    private static final String VALID_COMMAND_WORD_WITH_INVALID_TYPE = "add " + INVALID_TYPE;
+    private static final String VALID_COMMAND_WORD_WITH_MISSING_TYPE = "add";
 
     private static final FridgyParser testParser = new FridgyParser();
 
     @Test
     public void parseCommand_emptyInput_throwsParseException() {
         assertThrows(ParseException.class, () -> testParser.parseCommand(EMPTY_COMMAND));
+    }
+
+    @Test
+    public void parseCommand_cookCommandWordWithIngredientType_throwsParseException() {
+        String expectedMessage = Messages.MESSAGE_WRONG_TYPE + " "
+                + "'ingredient'"
+                + ". " + Messages.TYPE_RECIPE_EXPECTED;
+        System.out.println(expectedMessage);
+        FridgyParserTestUtil.assertParseFailure(testParser, COOK_COMMAND_WORD_WITH_INGREDIENT_TYPE, expectedMessage);
+    }
+
+    @Test
+    public void parseCommand_cookCommandWordWithInvalidType_throwsParseException() {
+        String expectedMessage = Messages.TYPE_INVALID_COMMAND_FORMAT + " "
+                + "'" + INVALID_TYPE + "'"
+                + ". " + Messages.TYPE_RECIPE_EXPECTED;
+        FridgyParserTestUtil.assertParseFailure(testParser, COOK_COMMAND_WORD_WITH_INVALID_TYPE, expectedMessage);
+    }
+
+    @Test
+    public void parseCommand_cookCommandWordWithMissingType_throwsParseException() {
+        String missingTypeMessage = String.format(Messages.MESSAGE_MISSING_TYPE, Messages.TYPE_RECIPE_EXPECTED);
+        String expectedMessage = String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                missingTypeMessage);
+        FridgyParserTestUtil.assertParseFailure(testParser, COOK_COMMAND_WORD_WITH_MISSING_TYPE, expectedMessage);
+    }
+
+    @Test
+    public void parseCommand_validCommandWordWithMissingType_throwsParseException() {
+        String missingTypeMessage = String.format(Messages.MESSAGE_MISSING_TYPE, Messages.TYPE_EXPECTED);
+        String expectedMessage = String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                missingTypeMessage);
+        FridgyParserTestUtil.assertParseFailure(testParser, VALID_COMMAND_WORD_WITH_MISSING_TYPE, expectedMessage);
+    }
+
+    @Test
+    public void parseCommand_validCommandWordWithInvalidType_throwsParseException() {
+        String expectedMessage = Messages.TYPE_INVALID_COMMAND_FORMAT + " "
+                + "'" + INVALID_TYPE + "'"
+                + ". " + Messages.TYPE_EXPECTED;
+        FridgyParserTestUtil.assertParseFailure(testParser, VALID_COMMAND_WORD_WITH_INVALID_TYPE, expectedMessage);
     }
 
     @Test

--- a/src/test/java/fridgy/logic/parser/FridgyParserTestUtil.java
+++ b/src/test/java/fridgy/logic/parser/FridgyParserTestUtil.java
@@ -1,0 +1,20 @@
+package fridgy.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import fridgy.logic.parser.exceptions.ParseException;
+
+public class FridgyParserTestUtil {
+    /**
+     * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
+     * equals to {@code expectedMessage}.
+     */
+    public static void assertParseFailure(FridgyParser parser, String userInput, String expectedMessage) {
+        try {
+            parser.parseCommand(userInput);
+            throw new AssertionError("The expected ParseException was not thrown.");
+        } catch (ParseException pe) {
+            assertEquals(expectedMessage, pe.getMessage());
+        }
+    }
+}

--- a/src/test/java/fridgy/model/ingredient/ExpiryDateTest.java
+++ b/src/test/java/fridgy/model/ingredient/ExpiryDateTest.java
@@ -34,6 +34,8 @@ public class ExpiryDateTest {
         assertFalse(ExpiryDate.isValidExpiry("24/10/2021")); // Wrong format, using "/" instead of "-"
         assertFalse(ExpiryDate.isValidExpiry("99-05-2021")); // excessive number of days
         assertFalse(ExpiryDate.isValidExpiry("05-99-2021")); // excessive number of months
+        assertFalse(ExpiryDate.isValidExpiry("00-00-0000")); // date does not exist
+        assertFalse(ExpiryDate.isValidExpiry("29-02-2021")); // date does not exist
 
 
         // valid expiry date


### PR DESCRIPTION
Fix #153 (by adding on that index should be a positive number to the invalid command error message
Fix possible issue with tags error message: valid tags need to be separated by a single space, so I added that to the error message
Fix #175, #193 #147 by making parser stricter (29-12-2021 is no longer allowed / rounded to the nearest valid date, 00-00-0000 is invalid), and made the error message more generic
Fix #168 
Fix #158 
Fix #152 Edit recipe and ingredient name message constraints
Add a specific check for commands with command word `cook` to display `recipe` as its expected type.
Add a check for valid command words but missing type in `parseGeneralCommand`.
Standardise punctuation for list command success message with `!`
Add plural to delete ingredient and recipe command success message
Add punctuation to invalid command error message and invalid command type error message
Add spaces to add recipe command example