### PR TITLE
Allow user to add ingredients with same name but different expiry dates

### DIFF
--- a/src/main/java/fridgy/model/ingredient/Ingredient.java
+++ b/src/main/java/fridgy/model/ingredient/Ingredient.java
@@ -73,7 +73,8 @@ public class Ingredient extends BaseIngredient {
         }
 
         return otherIngredient != null
-                && otherIngredient.getName().equals(getName());
+                && otherIngredient.getName().equals(getName())
+                && otherIngredient.getExpiryDate().equals(getExpiryDate());
     }
 
     @Override

--- a/src/test/java/fridgy/logic/commands/AddCommandTest.java
+++ b/src/test/java/fridgy/logic/commands/AddCommandTest.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.function.Predicate;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import fridgy.commons.core.GuiSettings;
@@ -22,8 +23,8 @@ import fridgy.model.base.ReadOnlyDatabase;
 import fridgy.model.ingredient.Ingredient;
 import fridgy.testutil.Assert;
 import fridgy.testutil.IngredientBuilder;
+import fridgy.testutil.TypicalIngredients;
 import javafx.collections.ObservableList;
-
 
 public class AddCommandTest {
 
@@ -75,6 +76,26 @@ public class AddCommandTest {
         // different Ingredient -> returns false
         assertFalse(addAlmondCommand.equals(addBasilCommand));
 
+    }
+
+    @Test
+    public void execute_sameIngredientDifferentExpiry_addSuccess() {
+        Ingredient almond1 = new IngredientBuilder(TypicalIngredients.ALMOND).withExpiryDate("11-03-2021").build();
+        Ingredient almond2 = new IngredientBuilder(TypicalIngredients.ALMOND).withExpiryDate("11-04-2021").build();
+        AddCommand addAlmond1Command = new AddCommand(almond1);
+        AddCommand addAlmond2Command = new AddCommand(almond2);
+        ModelStub testModel = new ModelStubAcceptingIngredientAdded();
+
+        CommandResult target1 = new CommandResult(String.format(AddCommand.MESSAGE_SUCCESS, almond1));
+        CommandResult target2 = new CommandResult(String.format(AddCommand.MESSAGE_SUCCESS, almond2));
+
+        try {
+            CommandResult result1 = addAlmond1Command.execute(testModel);
+            CommandResult result2 = addAlmond2Command.execute(testModel);
+            assertTrue(result1.equals(target1) && result2.equals(target2));
+        } catch (CommandException ce) {
+            Assertions.fail("CommandException thrown!");
+        }
     }
 
     /**

--- a/src/test/java/fridgy/model/ingredient/IngredientTest.java
+++ b/src/test/java/fridgy/model/ingredient/IngredientTest.java
@@ -49,6 +49,11 @@ public class IngredientTest {
         String nameWithTrailingSpaces = VALID_NAME_BASIL + " ";
         editedBasil = new IngredientBuilder(TypicalIngredients.BASIL).withName(nameWithTrailingSpaces).build();
         Assertions.assertFalse(TypicalIngredients.BASIL.isSameIngredient(editedBasil));
+
+        // same name, expiry dates different -> returns false
+        Ingredient editedBasil1 = new IngredientBuilder(TypicalIngredients.BASIL).withExpiryDate("11-03-2021").build();
+        Ingredient editedBasil2 = new IngredientBuilder(TypicalIngredients.BASIL).withExpiryDate("11-04-2021").build();
+        Assertions.assertFalse(editedBasil1.isSameIngredient(editedBasil2));
     }
 
     @Test


### PR DESCRIPTION
Fixes #179

Edited the isSameIngredient() method to allow for this comparison. However I have not changed the documentation in the UG for this behaviour, will be making changes to the UG in a different PR.