### PR TITLE
Reject 'expiry' or 'expiring' tags as userinput

### DIFF
--- a/src/main/java/fridgy/logic/parser/ParserUtil.java
+++ b/src/main/java/fridgy/logic/parser/ParserUtil.java
@@ -110,7 +110,7 @@ public class ParserUtil {
     public static Tag parseTag(String tag) throws ParseException {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
-        if (!Tag.isValidTagName(trimmedTag) || Tag.isExpiryRelated(trimmedTag)) {
+        if (!Tag.isValidTagName(trimmedTag) || Tag.isReservedTag(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
         return new Tag(trimmedTag);

--- a/src/main/java/fridgy/logic/parser/ParserUtil.java
+++ b/src/main/java/fridgy/logic/parser/ParserUtil.java
@@ -110,7 +110,7 @@ public class ParserUtil {
     public static Tag parseTag(String tag) throws ParseException {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
-        if (!Tag.isValidTagName(trimmedTag)) {
+        if (!Tag.isValidTagName(trimmedTag) || Tag.isExpiryRelated(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
         return new Tag(trimmedTag);

--- a/src/main/java/fridgy/model/tag/Tag.java
+++ b/src/main/java/fridgy/model/tag/Tag.java
@@ -2,6 +2,8 @@ package fridgy.model.tag;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
+
 import fridgy.commons.util.AppUtil;
 
 /**
@@ -9,9 +11,9 @@ import fridgy.commons.util.AppUtil;
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
  */
 public class Tag {
-
-    public static final String MESSAGE_CONSTRAINTS = "Tags should be alphanumeric, and should not be related to" +
-            " expiry dates. e.g. expired, expiring";
+    public static final String[] RESERVED_KEYWORDS = {"expired", "expiring"};
+    public static final String MESSAGE_CONSTRAINTS = "Tags should be alphanumeric, and should not use reserved "
+            + "keywords in any case:\n" + Arrays.toString(RESERVED_KEYWORDS);
     public static final String VALIDATION_REGEX = "^[a-zA-Z0-9]+( [a-zA-Z0-9]+)*$";
     public static final Tag EXPIRED = new Tag("expired");
     public static final Tag EXPIRING = new Tag("expiring");
@@ -40,12 +42,17 @@ public class Tag {
     }
 
     /**
-     * Returns true if a given string matches with either "expired" or "expiring".
+     * Returns true if a given string matches with any reserved keywords.
      * @param test string to be checked
-     * @return
+     * @return boolean true if it matches a reserved keyword, false otherwise.
      */
-    public static boolean isExpiryRelated(String test) {
-        return test.equalsIgnoreCase(EXPIRED.getTag()) || test.equalsIgnoreCase(EXPIRING.getTag());
+    public static boolean isReservedTag(String test) {
+        for (String reserved: RESERVED_KEYWORDS) {
+            if (test.equalsIgnoreCase(reserved)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/fridgy/model/tag/Tag.java
+++ b/src/main/java/fridgy/model/tag/Tag.java
@@ -10,7 +10,8 @@ import fridgy.commons.util.AppUtil;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tag names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS = "Tags should be alphanumeric, and should not be related to" +
+            " expiry dates. e.g. expired, expiring";
     public static final String VALIDATION_REGEX = "^[a-zA-Z0-9]+( [a-zA-Z0-9]+)*$";
     public static final Tag EXPIRED = new Tag("expired");
     public static final Tag EXPIRING = new Tag("expiring");
@@ -36,6 +37,15 @@ public class Tag {
      */
     public static boolean isValidTagName(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if a given string matches with either "expired" or "expiring".
+     * @param test string to be checked
+     * @return
+     */
+    public static boolean isExpiryRelated(String test) {
+        return test.equalsIgnoreCase(EXPIRED.getTag()) || test.equalsIgnoreCase(EXPIRING.getTag());
     }
 
     @Override

--- a/src/test/data/JsonInventoryStorageTest/invalidAndValidIngredientInventory.json
+++ b/src/test/data/JsonInventoryStorageTest/invalidAndValidIngredientInventory.json
@@ -2,13 +2,13 @@
   "ingredients": [ {
     "name": "Valid Ingredient",
     "quantity": "9482424",
-    "expiryDate" : "20-08-2010",
+    "expiryDate" : "20-08-2099",
     "description" : "4th street"
   }, {
     "name": "Ingredient With Invalid Quantity Field",
     "quantity": "948asdf2424",
     "address": "4th street",
-    "expiryDate" : "20-08-2010",
+    "expiryDate" : "20-08-2099",
     "description" : "4th street"
   } ]
 }

--- a/src/test/data/JsonSerializableInventoryTest/typicalIngredientsInventory.json
+++ b/src/test/data/JsonSerializableInventoryTest/typicalIngredientsInventory.json
@@ -5,42 +5,42 @@
     "quantity" : "94351253",
     "description" : "123, Jurong West Ave 6, #08-111",
     "tagged" : [ "snacks" ],
-    "expiryDate" : "20-08-2010"
+    "expiryDate" : "20-08-2099"
   }, {
     "name" : "Banana",
     "quantity" : "98765432",
     "description" : "311, Clementi Ave 2, #02-25",
     "tagged" : [ "fruit", "snacks" ],
-    "expiryDate" : "20-08-2010"
+    "expiryDate" : "20-08-2099"
   }, {
     "name" : "Carrot Slices",
     "quantity" : "95352563",
     "description" : "wall street",
     "tagged" : [ ],
-    "expiryDate" : "20-08-2010"
+    "expiryDate" : "20-08-2099"
   }, {
     "name" : "Duck breast",
     "quantity" : "87652533",
     "description" : "10th street",
     "tagged" : [ "snacks" ],
-    "expiryDate" : "20-08-2010"
+    "expiryDate" : "20-08-2099"
   }, {
     "name" : "Egg mayo",
     "quantity" : "9482224",
     "description" : "michegan ave",
     "tagged" : [ ],
-    "expiryDate" : "20-08-2010"
+    "expiryDate" : "20-08-2099"
   }, {
     "name" : "Fig jam",
     "quantity" : "9482427",
     "description" : "little tokyo",
     "tagged" : [ ],
-    "expiryDate" : "20-08-2010"
+    "expiryDate" : "20-08-2099"
   }, {
     "name" : "Grape",
     "quantity" : "9482442",
     "description" : "4th street",
     "tagged" : [ ],
-    "expiryDate" : "20-08-2010"
+    "expiryDate" : "20-08-2099"
   } ]
 }

--- a/src/test/java/fridgy/logic/commands/ClearCommandTest.java
+++ b/src/test/java/fridgy/logic/commands/ClearCommandTest.java
@@ -1,7 +1,10 @@
 package fridgy.logic.commands;
 
 import static fridgy.testutil.TypicalIngredients.CHICKEN;
+import static fridgy.testutil.TypicalIngredients.EXPIRED_CHICKEN;
+import static fridgy.testutil.TypicalIngredients.EXPIRED_FLOUR;
 import static fridgy.testutil.TypicalIngredients.FLOUR;
+import static fridgy.testutil.TypicalIngredients.getTypicalInventory;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,10 +13,10 @@ import fridgy.model.Model;
 import fridgy.model.ModelManager;
 import fridgy.model.RecipeBook;
 import fridgy.model.UserPrefs;
-import fridgy.testutil.TypicalIngredients;
 
 public class ClearCommandTest {
 
+    /*================================= testing clearing of all ingredients ==========================================*/
     @Test
     public void execute_emptyInventory_success() {
         Model model = new ModelManager();
@@ -25,8 +28,8 @@ public class ClearCommandTest {
 
     @Test
     public void execute_nonEmptyInventory_success() {
-        Model model = new ModelManager(TypicalIngredients.getTypicalInventory(), new RecipeBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(TypicalIngredients.getTypicalInventory(), new RecipeBook(),
+        Model model = new ModelManager(getTypicalInventory(), new RecipeBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalInventory(), new RecipeBook(),
                 new UserPrefs());
         expectedModel.setInventory(new Inventory());
 
@@ -34,22 +37,23 @@ public class ClearCommandTest {
                 expectedModel);
     }
 
+    /*================================= testing clearing of expired ingredients ======================================*/
     @Test
     public void execute_allExpiredIngredients_success() {
-        Model model = new ModelManager(TypicalIngredients.getTypicalInventory(), new RecipeBook(), new UserPrefs());
+        Model model = new ModelManager(new Inventory(), new RecipeBook(), new UserPrefs());
+        model.add(EXPIRED_FLOUR);
+        model.add(EXPIRED_CHICKEN);
         Model expectedModel = new ModelManager(new Inventory(), new RecipeBook(), new UserPrefs());
         CommandTestUtil.assertCommandSuccess(new ClearCommand(true), model,
                 ClearCommand.MESSAGE_SUCCESS_EXPIRED, expectedModel);
     }
 
     @Test
-    public void execute_expiredIngredients_success() {
-        Model model = new ModelManager(TypicalIngredients.getTypicalInventory(), new RecipeBook(), new UserPrefs());
-        model.add(CHICKEN);
-        model.add(FLOUR);
-        Model expectedModel = new ModelManager(new Inventory(), new RecipeBook(), new UserPrefs());
-        expectedModel.add(CHICKEN);
-        expectedModel.add(FLOUR);
+    public void execute_someExpiredIngredients_success() {
+        Model model = new ModelManager(getTypicalInventory(), new RecipeBook(), new UserPrefs());
+        model.add(EXPIRED_CHICKEN);
+        model.add(EXPIRED_FLOUR);
+        Model expectedModel = new ModelManager(getTypicalInventory(), new RecipeBook(), new UserPrefs());
         CommandTestUtil.assertCommandSuccess(new ClearCommand(true), model,
                 ClearCommand.MESSAGE_SUCCESS_EXPIRED, expectedModel);
     }

--- a/src/test/java/fridgy/logic/commands/CommandTestUtil.java
+++ b/src/test/java/fridgy/logic/commands/CommandTestUtil.java
@@ -35,7 +35,7 @@ public class CommandTestUtil {
     public static final String VALID_DESCRIPTION_FISH = " ";
     public static final String VALID_TAG_VEGETABLE = "vegetable";
     public static final String VALID_TAG_SNACK = "snack";
-    public static final String VALID_EXPIRY_DATE = "20-08-2010";
+    public static final String VALID_EXPIRY_DATE = "20-08-2099";
 
     public static final String NAME_DESC_ALMOND = " " + CliSyntax.PREFIX_NAME + VALID_NAME_ALMOND;
     public static final String NAME_DESC_BASIL = " " + CliSyntax.PREFIX_NAME + VALID_NAME_BASIL;

--- a/src/test/java/fridgy/model/InventoryTest.java
+++ b/src/test/java/fridgy/model/InventoryTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import fridgy.model.base.Database;
 import fridgy.model.ingredient.BaseIngredient;
+import fridgy.model.ingredient.ExpiryDate;
 import fridgy.model.ingredient.Ingredient;
 import fridgy.model.ingredient.Name;
 import fridgy.model.ingredient.Quantity;
@@ -35,6 +36,7 @@ public class InventoryTest {
 
     private final Inventory ingrInventory = new Inventory();
     private List<Ingredient> inventoryIngrList = Arrays.asList(CHICKEN, FLOUR, APPLE, ALMOND);
+    // this ingredient list will be sorted to: CHICKEN, FLOUR, ALMOND, APPLE
 
     @Test
     public void constructor() {
@@ -132,11 +134,11 @@ public class InventoryTest {
         friedChickenIngr.add(new BaseIngredient(new Name("cHiCKen"), new Quantity("500g")));
         friedChickenIngr.add(new BaseIngredient(new Name("FlOuR"), new Quantity("500g")));
         assertFalse(ingrInventory.deductIngredients(friedChickenIngr));
-        // chicken and flour should be used up and removed, only apple and almond will be left
-        assertEquals(ALMOND.getQuantity(), ingrInventory.getList().get(0).getQuantity());
-        assertEquals(APPLE.getQuantity(), ingrInventory.getList().get(1).getQuantity());
-        assertEquals(CHICKEN.getQuantity(), ingrInventory.getList().get(2).getQuantity());
-        assertEquals(FLOUR.getQuantity(), ingrInventory.getList().get(3).getQuantity());
+        // no matches, everything will be the same
+        assertEquals(CHICKEN.getQuantity(), ingrInventory.getList().get(0).getQuantity());
+        assertEquals(FLOUR.getQuantity(), ingrInventory.getList().get(1).getQuantity());
+        assertEquals(ALMOND.getQuantity(), ingrInventory.getList().get(2).getQuantity());
+        assertEquals(APPLE.getQuantity(), ingrInventory.getList().get(3).getQuantity());
     }
 
     @Test
@@ -147,12 +149,12 @@ public class InventoryTest {
         friedChickenIngr.add(new BaseIngredient(new Name("flour"), new Quantity("20g")));
         assertTrue(ingrInventory.deductIngredients(friedChickenIngr));
         // almond, apple, chicken and flour should be left
-        assertEquals(ALMOND.getQuantity(), ingrInventory.getList().get(0).getQuantity());
-        assertEquals(APPLE.getQuantity(), ingrInventory.getList().get(1).getQuantity());
         // chicken should be left with 2kg - 20g = 1980g
         // flour should be left with 500g - 20g = 480g
-        assertEquals(new Quantity("1980 g"), ingrInventory.getList().get(2).getQuantity());
-        assertEquals(new Quantity("480 g"), ingrInventory.getList().get(3).getQuantity());
+        assertEquals(new Quantity("1980 g"), ingrInventory.getList().get(0).getQuantity());
+        assertEquals(new Quantity("480 g"), ingrInventory.getList().get(1).getQuantity());
+        assertEquals(ALMOND.getQuantity(), ingrInventory.getList().get(2).getQuantity());
+        assertEquals(APPLE.getQuantity(), ingrInventory.getList().get(3).getQuantity());
     }
 
     @Test
@@ -163,23 +165,30 @@ public class InventoryTest {
         friedChickenIngr.add(new BaseIngredient(new Name("flour"), new Quantity("300kg")));
         assertFalse(ingrInventory.deductIngredients(friedChickenIngr));
         // nothing should be deducted, since there is insufficient quantities in inventory
-        assertEquals(ALMOND.getQuantity(), ingrInventory.getList().get(0).getQuantity());
-        assertEquals(APPLE.getQuantity(), ingrInventory.getList().get(1).getQuantity());
-        assertEquals(CHICKEN.getQuantity(), ingrInventory.getList().get(2).getQuantity());
-        assertEquals(FLOUR.getQuantity(), ingrInventory.getList().get(3).getQuantity());
+        assertEquals(CHICKEN.getQuantity(), ingrInventory.getList().get(0).getQuantity());
+        assertEquals(FLOUR.getQuantity(), ingrInventory.getList().get(1).getQuantity());
+        assertEquals(ALMOND.getQuantity(), ingrInventory.getList().get(2).getQuantity());
+        assertEquals(APPLE.getQuantity(), ingrInventory.getList().get(3).getQuantity());
     }
 
     @Test
     public void deductIngredients_expiredIngr_returnsFalse() {
         ingrInventory.setItems(inventoryIngrList);
-        Set<BaseIngredient> fruitAndNutsIngr = new HashSet<>();
-        fruitAndNutsIngr.add(new BaseIngredient(new Name("apple"), new Quantity("1")));
-        fruitAndNutsIngr.add(new BaseIngredient(new Name("almond"), new Quantity("1")));
-        assertFalse(ingrInventory.deductIngredients(fruitAndNutsIngr));
+        // adding expired items
+        ingrInventory.add(new Ingredient(new Name("mango"), new Quantity("5"),
+                new HashSet<>(), new ExpiryDate("20-10-1975")));
+        ingrInventory.add(new Ingredient(new Name("monga"), new Quantity("5"),
+                new HashSet<>(), new ExpiryDate("20-10-1975")));
+        Set<BaseIngredient> fruityIngr = new HashSet<>();
+        fruityIngr.add(new BaseIngredient(new Name("mango"), new Quantity("1")));
+        fruityIngr.add(new BaseIngredient(new Name("monga"), new Quantity("1")));
+        assertFalse(ingrInventory.deductIngredients(fruityIngr));
         // deductIngredients does not allow deduction of expired ingredients, so nothing should be deducted
-        assertEquals(ALMOND.getQuantity(), ingrInventory.getList().get(0).getQuantity());
-        assertEquals(APPLE.getQuantity(), ingrInventory.getList().get(1).getQuantity());
+        assertEquals(new Quantity("5"), ingrInventory.getList().get(0).getQuantity());
+        assertEquals(new Quantity("5"), ingrInventory.getList().get(1).getQuantity());
         assertEquals(CHICKEN.getQuantity(), ingrInventory.getList().get(2).getQuantity());
         assertEquals(FLOUR.getQuantity(), ingrInventory.getList().get(3).getQuantity());
+        assertEquals(ALMOND.getQuantity(), ingrInventory.getList().get(4).getQuantity());
+        assertEquals(APPLE.getQuantity(), ingrInventory.getList().get(5).getQuantity());
     }
 }

--- a/src/test/java/fridgy/model/ingredient/ExpiryStatusUpdaterTest.java
+++ b/src/test/java/fridgy/model/ingredient/ExpiryStatusUpdaterTest.java
@@ -15,8 +15,8 @@ import fridgy.testutil.IngredientBuilder;
 public class ExpiryStatusUpdaterTest {
     @Test
     public void updateExpiryTags_updateCorrectly() {
-        // by default, it is expired
-        Ingredient expiredIngredient = new IngredientBuilder().build();
+        // setting as expired
+        Ingredient expiredIngredient = new IngredientBuilder().withExpiryDate("20-10-1979").build();
         Set<Tag> setWithDefaultExpired = Set.of(Tag.EXPIRED);
         assertEquals(setWithDefaultExpired, ExpiryStatusUpdater.updateExpiryTags(expiredIngredient).getTags());
 

--- a/src/test/java/fridgy/testutil/IngredientBuilder.java
+++ b/src/test/java/fridgy/testutil/IngredientBuilder.java
@@ -23,8 +23,8 @@ public class IngredientBuilder {
     public static final String DEFAULT_NAME = "Almond";
     public static final String DEFAULT_QUANTITY = "50g";
     public static final String DEFAULT_DESCRIPTION = "Nut";
-    public static final String DEFAULT_EXPIRY_DATE = "20-08-2010";
-    public static final Set<Tag> DEFAULT_TAGS = Set.of(Tag.EXPIRED);
+    public static final String DEFAULT_EXPIRY_DATE = "20-08-2099";
+    public static final Set<Tag> DEFAULT_TAGS = new HashSet<>();
 
     private Name name;
     private Quantity quantity;

--- a/src/test/java/fridgy/testutil/TypicalIngredients.java
+++ b/src/test/java/fridgy/testutil/TypicalIngredients.java
@@ -28,33 +28,35 @@ public class TypicalIngredients {
     public static final Ingredient APPLE = new IngredientBuilder().withName("Apple")
             .withDescription("123, Jurong West Ave 6, #08-111")
             .withQuantity("94351253").withTags("snacks")
-            .withExpiryDate("20-08-2010").build();
+            .withExpiryDate("20-08-2099").build();
     public static final Ingredient BANANA = new IngredientBuilder().withName("Banana")
             .withDescription("311, Clementi Ave 2, #02-25")
             .withQuantity("98765432").withTags("fruit", "snacks")
-            .withExpiryDate("20-08-2010").build();
+            .withExpiryDate("20-08-2099").build();
     public static final Ingredient CARROT = new IngredientBuilder().withName("Carrot Slices").withQuantity("95352563")
             .withDescription("wall street")
-            .withExpiryDate("20-08-2010").build();
+            .withExpiryDate("20-08-2099").build();
     public static final Ingredient DUCK = new IngredientBuilder().withName("Duck breast").withQuantity("87652533")
             .withDescription("10th street").withTags("snacks")
-            .withExpiryDate("20-08-2010").build();
+            .withExpiryDate("20-08-2099").build();
     public static final Ingredient EGG = new IngredientBuilder().withName("Egg mayo").withQuantity("9482224")
             .withDescription("michegan ave")
-            .withExpiryDate("20-08-2010").build();
+            .withExpiryDate("20-08-2099").build();
     public static final Ingredient FIGS = new IngredientBuilder().withName("Fig jam").withQuantity("9482427")
             .withDescription("little tokyo")
-            .withExpiryDate("20-08-2010").build();
+            .withExpiryDate("20-08-2099").build();
     public static final Ingredient GRAPES = new IngredientBuilder().withName("Grape").withQuantity("9482442")
             .withDescription("4th street")
-            .withExpiryDate("20-08-2010").build();
+            .withExpiryDate("20-08-2099").build();
 
     // Manually added
     public static final Ingredient CHICKEN = new IngredientBuilder().withName("chicken").withQuantity("2kg")
             .withExpiryDate("20-02-2070").build();
     public static final Ingredient FLOUR = new IngredientBuilder().withName("flour").withQuantity("500g")
             .withExpiryDate("20-02-2070").build();
-    public static final Ingredient EXPIRED_CHICKEN = new IngredientBuilder().withName("rotting chicken")
+    public static final Ingredient EXPIRED_CHICKEN = new IngredientBuilder().withName("chicken")
+            .withQuantity("2kg").withExpiryDate("20-02-1979").build();
+    public static final Ingredient EXPIRED_FLOUR = new IngredientBuilder().withName("flour")
             .withQuantity("2kg").withExpiryDate("20-02-1979").build();
     public static final Ingredient HOON = new IngredientBuilder().withName("Hoon Meier").withQuantity("8482424")
             .withDescription("little india")
@@ -69,8 +71,7 @@ public class TypicalIngredients {
             .withDescription(VALID_DESCRIPTION_ALMOND).withTags(VALID_TAG_SNACK).build();
     public static final Ingredient BASIL = new IngredientBuilder().withName(VALID_NAME_BASIL)
             .withQuantity(VALID_QUANTITY_BASIL)
-            .withDescription(VALID_DESCRIPTION_BASIL).withTags(VALID_TAG_VEGETABLE, VALID_TAG_SNACK)
-            .withExpiryDate("20-08-2010").build();
+            .withDescription(VALID_DESCRIPTION_BASIL).withTags(VALID_TAG_VEGETABLE, VALID_TAG_SNACK).build();
     public static final Ingredient FISH = new IngredientBuilder().withName(VALID_NAME_FISH)
             .withQuantity(VALID_QUANTITY_FISH)
             .withDescription(VALID_DESCRIPTION_FISH)


### PR DESCRIPTION
Fix #196

Now rejects `expiry` and `expiring` tags, regardless of case.